### PR TITLE
pass gomysql result from backend TiDB to server

### DIFF
--- a/pkg/proxy/driver/queryctx.go
+++ b/pkg/proxy/driver/queryctx.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
+	gomysql "github.com/siddontang/go-mysql/mysql"
 )
 
 // Server information.
@@ -97,7 +98,7 @@ func (q *QueryCtxImpl) CurrentDB() string {
 	return q.currentDB
 }
 
-func (q *QueryCtxImpl) Execute(ctx context.Context, sql string) ([]server.ResultSet, error) {
+func (q *QueryCtxImpl) Execute(ctx context.Context, sql string) (*gomysql.Result, error) {
 	return q.execute(ctx, sql)
 }
 

--- a/pkg/proxy/server/conn_net.go
+++ b/pkg/proxy/server/conn_net.go
@@ -247,6 +247,7 @@ func (cc *clientConn) writeGoMySQLChunks(ctx context.Context, rs *gomysql.Result
 
 	data := cc.alloc.AllocWithLen(4, 1024)
 	for _, v := range rs.RowDatas {
+		data = data[0:4]
 		// TODO(eastfisher): implement binary resultset
 		data = append(data, v...)
 		if err = cc.writePacket(data); err != nil {
@@ -265,8 +266,10 @@ func convertFieldsToColumnInfos(fields []*gomysql.Field) []*ColumnInfo {
 			OrgTable:           string(f.OrgTable),
 			Name:               string(f.Name),
 			OrgName:            string(f.OrgName),
-			Charset:            f.Charset,
 			ColumnLength:       f.ColumnLength,
+			Charset:            f.Charset,
+			Flag:               f.Flag,
+			Decimal:            f.Decimal,
 			Type:               f.Type,
 			DefaultValueLength: f.DefaultValueLength,
 			DefaultValue:       f.DefaultValue,

--- a/pkg/proxy/server/conn_net.go
+++ b/pkg/proxy/server/conn_net.go
@@ -228,7 +228,7 @@ func (cc *clientConn) writeGoMySQLResultset(ctx context.Context, rs *gomysql.Res
 	if mysql.HasCursorExistsFlag(serverStatus) {
 		// TODO(eastfisher): writeChunksWithFetchSize
 	} else {
-		err = cc.writeGoMySQLChunks(ctx, rs, binary, serverStatus)
+		err = cc.doWriteGoMySQLResultset(ctx, rs, binary, serverStatus)
 	}
 	if err != nil {
 		return err
@@ -237,7 +237,7 @@ func (cc *clientConn) writeGoMySQLResultset(ctx context.Context, rs *gomysql.Res
 	return cc.flush()
 }
 
-func (cc *clientConn) writeGoMySQLChunks(ctx context.Context, rs *gomysql.Resultset, binary bool, serverStatus uint16) error {
+func (cc *clientConn) doWriteGoMySQLResultset(ctx context.Context, rs *gomysql.Resultset, binary bool, serverStatus uint16) error {
 	var err error
 	columns := convertFieldsToColumnInfos(rs.Fields)
 	err = cc.writeColumnInfo(columns, serverStatus)

--- a/pkg/proxy/server/conn_net.go
+++ b/pkg/proxy/server/conn_net.go
@@ -273,6 +273,7 @@ func convertFieldsToColumnInfos(fields []*gomysql.Field) []*ColumnInfo {
 		}
 		rets = append(rets, ret)
 	}
+	return rets
 }
 
 func (cc *clientConn) writeColumnInfo(columns []*ColumnInfo, serverStatus uint16) error {

--- a/pkg/proxy/server/driver.go
+++ b/pkg/proxy/server/driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/siddontang/go-mysql/mysql"
 )
 
 // IDriver opens IContext.
@@ -67,7 +68,7 @@ type QueryCtx interface {
 	CurrentDB() string
 
 	// Execute executes a SQL statement.
-	Execute(ctx context.Context, sql string) ([]ResultSet, error)
+	Execute(ctx context.Context, sql string) (*mysql.Result, error)
 
 	// ExecuteInternal executes a internal SQL statement.
 	ExecuteInternal(ctx context.Context, sql string) ([]ResultSet, error)


### PR DESCRIPTION
<!--
Thank you for working on Weir! Please read Weir's [CONTRIBUTING](https://github.com/pingcap-incubator/weir/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

use go-mysql Result instead of server ResultSet

### What problem does this PR solve?

Timestamp parse error

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Pass go-mysql Result from backend to server

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test
