### PR TITLE
add error close in PooledBackendConn

### DIFF
--- a/pkg/proxy/backend/backend.go
+++ b/pkg/proxy/backend/backend.go
@@ -114,7 +114,7 @@ func (b *BackendImpl) initConnPools() error {
 	return nil
 }
 
-func (b *BackendImpl) GetConn(ctx context.Context) (driver.BackendConn, error) {
+func (b *BackendImpl) GetConn(ctx context.Context) (driver.SimpleBackendConn, error) {
 	if b.closed.Get() {
 		return nil, ErrBackendClosed
 	}

--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -18,12 +18,21 @@ type Namespace interface {
 }
 
 type PooledBackendConn interface {
+	// PutBack put conn back to pool
 	PutBack()
+
+	// ErrorClose close conn and connpool create a new conn
+	// call this function when conn is broken.
+	ErrorClose() error
+	BackendConn
+}
+
+type SimpleBackendConn interface {
+	Close() error
 	BackendConn
 }
 
 type BackendConn interface {
-	Close() error
 	Ping() error
 	UseDB(dbName string) error
 	GetDB() string

--- a/pkg/proxy/driver/queryctx_exec.go
+++ b/pkg/proxy/driver/queryctx_exec.go
@@ -276,7 +276,7 @@ func (q *QueryCtxImpl) initTxnConn(ctx context.Context) error {
 func (q *QueryCtxImpl) postUseTxnConn(err error) {
 	if err != nil {
 		if q.txnConn != nil {
-			if errClose := q.txnConn.Close(); errClose != nil {
+			if errClose := q.txnConn.ErrorClose(); errClose != nil {
 				logutil.BgLogger().Error("close txn conn error", zap.Error(errClose), zap.String("namespace", q.ns.Name()))
 			}
 			q.txnConn = nil

--- a/tests/proxy/backend/connpool_test.go
+++ b/tests/proxy/backend/connpool_test.go
@@ -1,0 +1,42 @@
+package backend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap-incubator/weir/pkg/proxy/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnPool_ErrorClose_Success(t *testing.T) {
+	cfg := backend.ConnPoolConfig{
+		Config: backend.Config{
+			Addr:"127.0.0.1:3306",
+			UserName:"root",
+			Password:"123456",
+		},
+		Capacity:1, // pool size is set to 1
+		IdleTimeout:0,
+	}
+	pool := backend.NewConnPool(&cfg)
+	err := pool.Init()
+	require.NoError(t, err)
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancelFunc()
+
+	conn1, err := pool.GetConn(ctx)
+	require.NoError(t, err)
+
+	// conn is closed, and another conn is created by pool
+	err = conn1.ErrorClose()
+	require.NoError(t, err)
+
+	conn2, err := pool.GetConn(ctx)
+	require.NoError(t, err)
+
+	err = conn2.ErrorClose()
+	require.NoError(t, err)
+}
+


### PR DESCRIPTION
<!--
Thank you for working on Weir! Please read Weir's [CONTRIBUTING](https://github.com/pingcap-incubator/weir/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

add error close in PooledBackendConn

### What problem does this PR solve?

Currently, closing a PooledBackendConn may cause connection pool size decrease. This PR add ErrorClose() to solve it.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

- Integration test (in tests/)

Side effects

- Breaking backward compatibility (interface changes)
