### PR TITLE
fix txn conn execute error

### DIFF
--- a/pkg/proxy/driver/attached_conn.go
+++ b/pkg/proxy/driver/attached_conn.go
@@ -139,10 +139,6 @@ func (a *AttachedConnHolder) ExecuteQuery(ctx context.Context, query func(ctx co
 	defer a.txnLock.Unlock()
 
 	var err error
-	defer func() {
-		a.postUseTxnConn(err)
-	}()
-
 	if err = a.initTxnConn(ctx); err != nil {
 		return nil, err
 	}
@@ -205,10 +201,6 @@ func (a *AttachedConnHolder) StmtExecuteForward(stmtId int, data []byte) (*gomys
 	defer a.txnLock.Unlock()
 
 	var err error
-	defer func() {
-		a.postUseTxnConn(err)
-	}()
-
 	if !a.prepareStmtHolder.isStmtIdExist(stmtId) {
 		err = errors.New("stmt id not found")
 		return nil, err

--- a/pkg/proxy/driver/attached_conn_test.go
+++ b/pkg/proxy/driver/attached_conn_test.go
@@ -298,7 +298,6 @@ func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_AndThen_Commit_S
 	expectResult := &gomysql.Result{}
 	mockPooledBackendConn.On("IsAutoCommit").Return(true).Once()
 	mockPooledBackendConn.On("Execute", sql).Return(expectResult, nil).Once()
-	mockPooledBackendConn.On("IsAutoCommit").Return(true).Once()
 
 	queryFunc := func(ctx context.Context, conn PooledBackendConn) (*gomysql.Result, error) {
 		return conn.Execute(sql)
@@ -314,6 +313,7 @@ func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_AndThen_Commit_S
 
 	// commit
 	mockPooledBackendConn.On("Commit").Return(nil)
+	mockPooledBackendConn.On("IsAutoCommit").Return(true).Once()
 	mockPooledBackendConn.On("PutBack").Return()
 
 	err = a.mockHolder.CommitOrRollback(true)
@@ -354,12 +354,13 @@ func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_Error_AndThen_Co
 	_, err = a.mockHolder.ExecuteQuery(ctx, queryFunc)
 	assert.EqualError(a.T(), err, mockError.Error())
 	mockPooledBackendConn.AssertCalled(a.T(), "Execute", sql)
-	assert.Nil(a.T(), a.mockHolder.txnConn)
+	assert.NotNil(a.T(), a.mockHolder.txnConn)
 	require.Equal(a.T(), true, a.mockHolder.IsAutoCommit())
 	require.Equal(a.T(), true, a.mockHolder.IsInTransaction())
 
 	// commit
 	mockPooledBackendConn.On("Commit").Return(nil)
+	mockPooledBackendConn.On("IsAutoCommit").Return(true).Once()
 	mockPooledBackendConn.On("PutBack").Return()
 
 	err = a.mockHolder.CommitOrRollback(true)
@@ -400,9 +401,9 @@ func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_Error_AndThen_Co
 	_, err = a.mockHolder.ExecuteQuery(ctx, queryFunc)
 	assert.EqualError(a.T(), err, mockError.Error())
 	mockPooledBackendConn.AssertCalled(a.T(), "Execute", sql)
-	assert.Nil(a.T(), a.mockHolder.txnConn)
+	assert.NotNil(a.T(), a.mockHolder.txnConn)
 	require.Equal(a.T(), true, a.mockHolder.IsAutoCommit())
-	require.Equal(a.T(), false, a.mockHolder.IsInTransaction())
+	require.Equal(a.T(), true, a.mockHolder.IsInTransaction())
 
 	// commit error should close backend conn
 	mockPooledBackendConn.On("Commit").Return(mockError)
@@ -417,7 +418,6 @@ func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_Error_AndThen_Co
 	require.Nil(a.T(), a.mockHolder.txnConn)
 }
 
-// FIXME(eastfisher): need rollback
 func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_AndThen_Commit_Error_EnableAutoCommit() {
 	ctx := context.Background()
 
@@ -457,14 +457,11 @@ func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_AndThen_Commit_E
 	// commit
 	mockPooledBackendConn.On("IsAutoCommit").Return(true).Once()
 	mockPooledBackendConn.On("Commit").Return(mockError).Once()
-	//mockPooledBackendConn.On("Rollback").Return(nil).Once()
 	mockPooledBackendConn.On("ErrorClose").Return(nil).Once()
 
 	err = a.mockHolder.CommitOrRollback(true)
 	require.EqualError(a.T(), err, mockError.Error())
 
-	// FIXME(eastfisher): rollback
-	//mockPooledBackendConn.AssertCalled(a.T(), "Rollback")
 	mockPooledBackendConn.AssertCalled(a.T(), "ErrorClose")
 	require.Equal(a.T(), true, a.mockHolder.IsAutoCommit())
 	require.Equal(a.T(), false, a.mockHolder.IsInTransaction())

--- a/pkg/proxy/driver/attached_conn_test.go
+++ b/pkg/proxy/driver/attached_conn_test.go
@@ -157,11 +157,13 @@ func (a *AttachedConnTestSuite) Test_Commit_AutoCommit_WithBegin_ErrorCommit() {
 	require.Equal(a.T(), true, a.mockHolder.IsInTransaction())
 	require.NotNil(a.T(), a.mockHolder.txnConn)
 
-	mockPooledBackendConn.On("Commit").Return(mockError)
-	mockPooledBackendConn.On("ErrorClose").Return(nil)
+	mockPooledBackendConn.On("Commit").Return(mockError).Once()
+	mockPooledBackendConn.On("ErrorClose").Return(nil).Once()
 
 	err = a.mockHolder.CommitOrRollback(true)
 	require.EqualError(a.T(), err, mockError.Error())
+	mockPooledBackendConn.AssertCalled(a.T(), "Commit")
+	mockPooledBackendConn.AssertCalled(a.T(), "ErrorClose")
 	require.Equal(a.T(), true, a.mockHolder.IsAutoCommit())
 	require.Equal(a.T(), false, a.mockHolder.IsInTransaction())
 	require.Nil(a.T(), a.mockHolder.txnConn)
@@ -316,6 +318,7 @@ func (a *AttachedConnTestSuite) Test_Begin_AndThen_ExecuteQuery_AndThen_Commit_S
 
 	err = a.mockHolder.CommitOrRollback(true)
 	require.NoError(a.T(), err)
+	mockPooledBackendConn.AssertCalled(a.T(), "Commit")
 	mockPooledBackendConn.AssertCalled(a.T(), "PutBack")
 	require.Equal(a.T(), true, a.mockHolder.IsAutoCommit())
 	require.Equal(a.T(), false, a.mockHolder.IsInTransaction())


### PR DESCRIPTION
<!--
Thank you for working on Weir! Please read Weir's [CONTRIBUTING](https://github.com/pingcap-incubator/weir/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

When execute in transaction, error should not close and release backend conn.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Do not close backend conn when error occurs in executing SQL in transaction.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Side effects

- actions in transaction
