### PR TITLE
support set session system variables

### DIFF
--- a/pkg/proxy/backend/connpool.go
+++ b/pkg/proxy/backend/connpool.go
@@ -128,6 +128,7 @@ func (cw *backendPooledConnWrapper) syncSessionVariables(ctx context.Context) er
 
 	_, err = cw.Execute(setSQL)
 	if err != nil {
+		logutil.BgLogger().Error("execute sysvar sql error", zap.Error(err), zap.String("sql", setSQL))
 		return errors.WithMessage(err, "set sysvar error")
 	}
 
@@ -145,7 +146,7 @@ func (cw *noErrorCloseConnWrapper) Close() {
 
 var noValueSysVars = map[string]*ast.VariableAssignment{}
 
-const RestoreSetVariableFlags = format.DefaultRestoreFlags | format.RestoreStringEscapeBackslash
+const RestoreSetVariableFlags = format.RestoreStringSingleQuotes | format.RestoreKeyWordUppercase
 
 func getSysVarsFromCtx(ctx context.Context) map[string]*ast.VariableAssignment {
 	v := ctx.Value(constant.ContextKeySessionVariable)

--- a/pkg/proxy/backend/connpool.go
+++ b/pkg/proxy/backend/connpool.go
@@ -3,12 +3,16 @@ package backend
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pingcap-incubator/weir/pkg/proxy/backend/client"
+	"github.com/pingcap-incubator/weir/pkg/proxy/constant"
 	"github.com/pingcap-incubator/weir/pkg/proxy/driver"
 	"github.com/pingcap-incubator/weir/pkg/util/pool"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/format"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 )
@@ -35,6 +39,7 @@ type backendPooledConnWrapper struct {
 	addr     string
 	username string
 	pool     *pool.ResourcePool
+	sysvars  map[string]*ast.VariableAssignment
 }
 
 // this struct is only used for fitting pool.Resource interface
@@ -54,6 +59,7 @@ func newConnWrapper(pool *pool.ResourcePool, conn *client.Conn, addr, username s
 		addr:     addr,
 		username: username,
 		pool:     pool,
+		sysvars:  make(map[string]*ast.VariableAssignment),
 	}
 }
 
@@ -76,7 +82,13 @@ func (c *ConnPool) GetConn(ctx context.Context) (driver.PooledBackendConn, error
 	if err != nil {
 		return nil, err
 	}
-	return rs.(*noErrorCloseConnWrapper).backendPooledConnWrapper, nil
+
+	conn := rs.(*noErrorCloseConnWrapper).backendPooledConnWrapper
+	if err := conn.syncSessionVariables(ctx); err != nil {
+		return nil, errors.WithMessage(err, "sync sysvar error")
+	}
+
+	return conn, nil
 }
 
 func (c *ConnPool) Close() error {
@@ -101,10 +113,86 @@ func (cw *backendPooledConnWrapper) Close() error {
 	return cw.Conn.Close()
 }
 
+func (cw *backendPooledConnWrapper) syncSessionVariables(ctx context.Context) error {
+	sysVars := getSysVarsFromCtx(ctx)
+	varsToSet, varsToRemove := getDiffVariableList(sysVars, cw.sysvars)
+	if len(varsToSet) == 0 && len(varsToRemove) == 0 {
+		return nil
+	}
+
+	setSQL, err := getSetSysVarsSQL(varsToSet, varsToRemove)
+	logutil.BgLogger().Debug("backend conn set sysvar sql", zap.String("sql", setSQL), zap.Error(err))
+	if err != nil {
+		return errors.WithMessage(err, "get set sysvar sql error")
+	}
+
+	_, err = cw.Execute(setSQL)
+	if err != nil {
+		return errors.WithMessage(err, "set sysvar error")
+	}
+
+	cw.sysvars = sysVars
+	return nil
+}
+
 func (cw *noErrorCloseConnWrapper) Close() {
 	if err := cw.backendPooledConnWrapper.Close(); err != nil {
 		// TODO: log namespace info
 		logutil.BgLogger().Error("close backend conn error", zap.String("addr", cw.addr),
 			zap.String("username", cw.username), zap.Error(err))
 	}
+}
+
+var noValueSysVars = map[string]*ast.VariableAssignment{}
+
+const RestoreSetVariableFlags = format.DefaultRestoreFlags | format.RestoreStringEscapeBackslash
+
+func getSysVarsFromCtx(ctx context.Context) map[string]*ast.VariableAssignment {
+	v := ctx.Value(constant.ContextKeySessionVariable)
+	if v == nil {
+		return noValueSysVars
+	}
+	return v.(map[string]*ast.VariableAssignment)
+}
+
+func getSetSysVarsSQL(toSet, toRemove []*ast.VariableAssignment) (string, error) {
+	stmt := &ast.SetStmt{}
+	for _, v := range toSet {
+		stmt.Variables = append(stmt.Variables, v)
+	}
+
+	for _, v := range toRemove {
+		defaultVar := &ast.VariableAssignment{
+			Name:     v.Name,
+			Value:    &ast.DefaultExpr{},
+			IsGlobal: false,
+			IsSystem: true,
+		}
+		stmt.Variables = append(stmt.Variables, defaultVar)
+	}
+
+	return getRestoreSQLFromStmt(stmt)
+}
+
+func getRestoreSQLFromStmt(stmt *ast.SetStmt) (string, error) {
+	sb := &strings.Builder{}
+	restoreCtx := format.NewRestoreCtx(RestoreSetVariableFlags, sb)
+	if err := stmt.Restore(restoreCtx); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+// get variables to set and variables to set default
+func getDiffVariableList(frontend, current map[string]*ast.VariableAssignment) ([]*ast.VariableAssignment, []*ast.VariableAssignment) {
+	var toSet, toRemove []*ast.VariableAssignment
+	for _, v := range frontend {
+		toSet = append(toSet, v)
+	}
+	for k, v := range current {
+		if _, ok := frontend[k]; !ok {
+			toRemove = append(toRemove, v)
+		}
+	}
+	return toSet, toRemove
 }

--- a/pkg/proxy/constant/context.go
+++ b/pkg/proxy/constant/context.go
@@ -1,0 +1,5 @@
+package constant
+
+const ContextKeyPrefix = "__w_"
+
+const ContextKeySessionVariable = ContextKeyPrefix + "session_sysvars"

--- a/pkg/proxy/driver/queryctx_exec.go
+++ b/pkg/proxy/driver/queryctx_exec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pingcap-incubator/weir/pkg/proxy/constant"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
@@ -99,6 +100,8 @@ func createShowDatabasesResult(dbNames []string) (*gomysql.Result, error) {
 }
 
 func (q *QueryCtxImpl) executeInBackend(ctx context.Context, sql string, stmtNode ast.StmtNode) (*gomysql.Result, error) {
+	ctx = context.WithValue(ctx, constant.ContextKeySessionVariable, q.sessionVars.GetAllSystemVars())
+
 	result, err := q.connMgr.Query(ctx, q.currentDB, sql)
 	if err != nil {
 		return nil, err

--- a/pkg/proxy/driver/queryctx_exec.go
+++ b/pkg/proxy/driver/queryctx_exec.go
@@ -174,7 +174,7 @@ func (q *QueryCtxImpl) setSysVar(ctx context.Context, v *ast.VariableAssignment)
 	}
 	valueStr := fmt.Sprintf("%v", value.GetValue())
 
-	if err := q.sessionVars.SetSystemVar(v.Name, valueStr); err != nil {
+	if err := q.sessionVars.SetSystemVarAST(v.Name, v, valueStr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/proxy/driver/sessionvars.go
+++ b/pkg/proxy/driver/sessionvars.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/pingcap/parser/ast"
@@ -32,18 +33,22 @@ func (s *SessionVarsWrapper) GetAllSystemVars() map[string]*ast.VariableAssignme
 	return ret
 }
 
-func (s *SessionVarsWrapper) SetSystemVarAST(name string, v *ast.VariableAssignment, val string) error {
-	// only for checking
-	if err := s.sessionVars.SetSystemVar(name, val); err != nil {
-		return err
-	}
-
+func (s *SessionVarsWrapper) SetSystemVarAST(name string, v *ast.VariableAssignment) {
 	s.sessionVarMap[name] = v
+}
+
+func (s *SessionVarsWrapper) CheckSessionSysVarValid(name string) error {
+	sysVar := variable.GetSysVar(name)
+	if sysVar == nil {
+		return fmt.Errorf("%s is not a valid sysvar", name)
+	}
+	if (sysVar.Scope & variable.ScopeSession) == 0 {
+		return fmt.Errorf("%s is not a session scope sysvar", name)
+	}
 	return nil
 }
 
 func (s *SessionVarsWrapper) SetSystemVarDefault(name string) {
-	// TODO(eastfisher): need to set sessionVars default?
 	delete(s.sessionVarMap, name)
 }
 

--- a/pkg/proxy/driver/sessionvars.go
+++ b/pkg/proxy/driver/sessionvars.go
@@ -14,7 +14,10 @@ type SessionVarsWrapper struct {
 }
 
 func NewSessionVarsWrapper(sessionVars *variable.SessionVars) *SessionVarsWrapper {
-	return &SessionVarsWrapper{sessionVars: sessionVars}
+	return &SessionVarsWrapper{
+		sessionVars:   sessionVars,
+		sessionVarMap: make(map[string]*ast.VariableAssignment),
+	}
 }
 
 func (s *SessionVarsWrapper) SessionVars() *variable.SessionVars {

--- a/pkg/proxy/driver/sessionvars.go
+++ b/pkg/proxy/driver/sessionvars.go
@@ -7,8 +7,9 @@ import (
 )
 
 type SessionVarsWrapper struct {
-	sessionVars  *variable.SessionVars
-	affectedRows uint64
+	sessionVarSet map[string]struct{}
+	sessionVars   *variable.SessionVars
+	affectedRows  uint64
 }
 
 func NewSessionVarsWrapper(sessionVars *variable.SessionVars) *SessionVarsWrapper {
@@ -19,12 +20,30 @@ func (s *SessionVarsWrapper) SessionVars() *variable.SessionVars {
 	return s.sessionVars
 }
 
+func (s *SessionVarsWrapper) GetAllSystemVars() map[string]string {
+	ret := make(map[string]string)
+	for n := range s.sessionVarSet {
+		if v, ok := s.sessionVars.GetSystemVar(n); ok {
+			ret[n] = v
+		}
+	}
+	return ret
+}
+
 func (s *SessionVarsWrapper) GetSystemVar(name string) (string, bool) {
+	if _, ok := s.sessionVarSet[name]; !ok {
+		return "", false
+	}
 	return s.sessionVars.GetSystemVar(name)
 }
 
 func (s *SessionVarsWrapper) SetSystemVar(name string, val string) error {
+	s.sessionVarSet[name] = struct{}{}
 	return s.sessionVars.SetSystemVar(name, val)
+}
+
+func (s *SessionVarsWrapper) SetSystemVarDefault(name string) {
+	delete(s.sessionVarSet, name)
 }
 
 func (s *SessionVarsWrapper) Status() uint16 {

--- a/pkg/proxy/driver/sessionvars.go
+++ b/pkg/proxy/driver/sessionvars.go
@@ -64,6 +64,7 @@ func (s *SessionVarsWrapper) SetStatusFlag(flag uint16, on bool) {
 	s.sessionVars.SetStatusFlag(flag, on)
 }
 
+// TODO(eastfisher): remove this function
 func (s *SessionVarsWrapper) GetCharsetInfo() (charset, collation string) {
 	return s.sessionVars.GetCharsetInfo()
 }

--- a/pkg/proxy/driver/sessionvars.go
+++ b/pkg/proxy/driver/sessionvars.go
@@ -21,10 +21,10 @@ func (s *SessionVarsWrapper) SessionVars() *variable.SessionVars {
 	return s.sessionVars
 }
 
-func (s *SessionVarsWrapper) GetAllSystemVars() []*ast.VariableAssignment {
-	var ret []*ast.VariableAssignment
-	for _, v := range s.sessionVarMap {
-		ret = append(ret, v)
+func (s *SessionVarsWrapper) GetAllSystemVars() map[string]*ast.VariableAssignment {
+	ret := make(map[string]*ast.VariableAssignment, len(s.sessionVarMap))
+	for k, v := range s.sessionVarMap {
+		ret[k] = v
 	}
 	return ret
 }


### PR DESCRIPTION
<!--
Thank you for working on Weir! Please read Weir's [CONTRIBUTING](https://github.com/pingcap-incubator/weir/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

#6 support set session system variables

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

When client execute a SET statement, QueryCtx first parse the statement and check if it is a set session variable statement. Then the variables are stored in QueryCtx. When client execute a query SQL, QueryCtx forward the variables to backend connection, the connection first restore the SetStmt to a SET statement and execute, if execution is success, backend connection is used to execute query statement. 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- No code
